### PR TITLE
[DOCS] Updating a link in the eventing docs

### DIFF
--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -1,4 +1,4 @@
-This example shows how to wire [Kubernetes cluster events](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#event-v1-core),
+This example shows how to wire [Kubernetes cluster events](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#event-v1-core),
 using the API Server Source, for consumption by a function that has been implemented as a Knative Service.
 
 ## Before you begin


### PR DESCRIPTION
fix broken link cluster events k8s docs

The file `docs/eventing/samples/kubernetes-event-source/README.md` points to a link in the Kubernetes docs for release 1.17 and that file no longer exists. I've updated that link to match the URL for the 1.18 release of Kubernetes (`https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#event-v1-core`)
